### PR TITLE
[tar_git] Use tagger name, email and date for annotated tags in changelog

### DIFF
--- a/tar_git
+++ b/tar_git
@@ -452,9 +452,9 @@ get_changes_header () {
   local fmt='
     r=%(refname:short)
     t=%(*objecttype)
-    d=%(*committerdate:iso8601)
-    n=%(*authorname)
-    e=%(*authoremail)
+    d=%(taggerdate:iso8601)
+    n=%(taggername)
+    e=%(taggeremail)
   
     if test "z$t" = z
     then


### PR DESCRIPTION
When annotated tags are used to describe releases that may combine multiple commits from different authors, the creation of the tag itself is often more significant than the last commit to which the tag is pointing. Take the release author and date from the tag object instead of the last commit.